### PR TITLE
Deal methods

### DIFF
--- a/lib/deck_of_cards/packet.rb
+++ b/lib/deck_of_cards/packet.rb
@@ -48,6 +48,33 @@ class Packet
     end
   end
 
+  sig { returns(Card) }
+  def deal
+    raise StandardError if size.zero?
+
+    T.must(cards.slice!(0))
+  end
+
+  sig { returns(Card) }
+  def bottom_deal
+    raise StandardError if size.zero?
+
+    T.must(cards.pop)
+  end
+
+  sig { params(number_of_piles: Integer, number_of_cards: Integer).returns(T::Array[Packet]) }
+  def deal_into_piles(number_of_piles:, number_of_cards:)
+    raise StandardError, "Not enough cards" if (number_of_cards * number_of_piles) > size
+    raise StandardError, "Invalid number_of_cards" unless number_of_cards.positive?
+
+    piles = Array.new(number_of_piles) { [] }
+    number_of_cards.times do
+      piles.each { |pile| pile << deal }
+    end
+
+    piles.map { Packet.new(cards: _1) }
+  end
+
   sig { params(number: Integer).returns(Packet) }
   def cut(number:)
     raise ArgumentError if invalid_number_to_cut_to?(number)

--- a/test/test_packet.rb
+++ b/test/test_packet.rb
@@ -127,6 +127,38 @@ class PacketTest < Minitest::Test
     assert_equal "Duplicate card. (10 of H)", error.message
   end
 
+  def test_deal_deals_the_top_card
+    card = @full_deck.deal
+
+    assert_equal "A of C", card.to_s
+    assert_equal 51, @full_deck.size
+  end
+
+  def test_bottom_deal_deals_the_bottom_card
+    card = @full_deck.bottom_deal
+
+    assert_equal "K of D", card.to_s
+    assert_equal 51, @full_deck.size
+  end
+
+  def test_deal_into_piles_deals_into_x_number_of_piles
+    piles = @full_deck.deal_into_piles(number_of_piles: 4, number_of_cards: 5)
+
+    assert_equal 4, piles.size
+    assert(piles.all? { _1.size == 5 })
+    assert_equal 32, @full_deck.size
+  end
+
+  def test_deal_into_piles_deals_into_x_number_of_piles_raises_on_invalid_numbers
+    assert_raises do
+      @full_deck.deal_into_piles(number_of_piles: 4, number_of_cards: -5)
+    end
+
+    assert_raises do
+      @full_deck.deal_into_piles(number_of_piles: -4, number_of_cards: 5)
+    end
+  end
+
   private
 
   def create_full_deck


### PR DESCRIPTION
# Add dealing methods to Packet class

- Added `deal` method to remove and return the top card from a packet
- Added `bottom_deal` method to remove and return the bottom card from a packet
- Added `deal_into_piles` method to distribute cards into a specified number of piles with a specified number of cards per pile
- Added tests for all new dealing functionality