### PR TITLE
Move set_cards_positions to class method

### DIFF
--- a/lib/deck_of_cards/packet.rb
+++ b/lib/deck_of_cards/packet.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # This represents a packet of cards
-class Packet
+class Packet # rubocop:disable Metrics/ClassLength
   extend T::Sig
 
   sig { returns(T::Array[Card]) }
@@ -42,9 +42,18 @@ class Packet
       end
 
       packet = Packet.new(cards:)
-      packet.set_cards_positions
+      set_cards_positions(packet:)
 
       packet
+    end
+
+    private
+
+    sig { params(packet: Packet).void }
+    def set_cards_positions(packet:)
+      packet.cards.each_with_index do |card, index|
+        card.position = index + 1
+      end
     end
   end
 
@@ -136,13 +145,6 @@ class Packet
   sig { returns(T::Array[String]) }
   def to_s
     cards.map(&:to_s)
-  end
-
-  sig { void }
-  def set_cards_positions
-    cards.each_with_index do |card, index|
-      card.position = index + 1
-    end
   end
 
   private

--- a/test/test_packet.rb
+++ b/test/test_packet.rb
@@ -53,7 +53,7 @@ class PacketTest < Minitest::Test
     assert_equal first_card, last_card
   end
 
-  def test_creates_the_mnemonica_stack # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def test_manually_create_the_mnemonica_stack # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     clubs = @full_deck.cards.select { |card| card.suit == "C" }
     hearts = @full_deck.cards.select { |card| card.suit == "H" }
     spades = @full_deck.cards.select { |card| card.suit == "S" }
@@ -79,7 +79,6 @@ class PacketTest < Minitest::Test
 
     # cut the 9D to the bottom
     deck.cut_and_complete(number: 9)
-    deck.set_cards_positions
 
     first_card = T.must(deck.cards.first)
     assert_equal "C", first_card.suit
@@ -116,6 +115,13 @@ class PacketTest < Minitest::Test
     assert_equal 52, packet.size
     assert_equal "4 of C", packet.cards.first.to_s
     assert_equal "9 of D", packet.cards.last.to_s
+  end
+
+  def test_build_from_text_file_assigns_positions_to_cards
+    file_path = "data/mnemonica.txt"
+    packet = Packet.build_from_text_file(file_path:)
+
+    assert_equal (1..52).to_a, packet.cards.map(&:position)
   end
 
   def test_build_from_text_file_raise_error_on_duplicate_cards

--- a/test/test_packet.rb
+++ b/test/test_packet.rb
@@ -4,10 +4,8 @@
 require "test_helper"
 require "debug"
 
-class PacketTest < Minitest::Test
-  def setup
-    @full_deck = create_full_deck
-  end
+class PacketTest < Minitest::Test # rubocop:disable Metrics/ClassLength
+  extend T::Sig
 
   def test_a_packet_must_contain_at_least_one_card
     assert_raises ArgumentError do
@@ -29,23 +27,29 @@ class PacketTest < Minitest::Test
   end
 
   def test_cut_cuts_a_packet_of_x_number_of_cards
-    packet = @full_deck.cut(number: 26)
+    deck = create_full_deck
+    packet = deck.cut(number: 26)
     assert_equal 26, packet.size
-    assert_equal 26, @full_deck.size
+    assert_equal 26, deck.size
   end
 
-  def test_faro_two_packets_of_cards
-    deck = @full_deck
-    refute_equal deck.cards[0].value, deck.cards[1].value
+  def test_faro_two_packets_of_cards # rubocop:disable Metrics/AbcSize
+    deck = create_full_deck
+
+    first_card = T.must(deck.cards[0])
+    second_card = T.must(deck.cards[1])
+    refute_equal first_card.value, second_card.value
 
     cut_cards = deck.cut(number: 26)
     deck.faro(other_packet: cut_cards)
 
-    assert_equal deck.cards[0].value, deck.cards[1].value
+    first_card = T.must(deck.cards[0])
+    second_card = T.must(deck.cards[1])
+    assert_equal first_card.value, second_card.value
   end
 
   def test_reverse_reverses_the_order_of_the_cards
-    deck = @full_deck
+    deck = create_full_deck
     first_card = deck.cards.first
     deck.reverse
     last_card = deck.cards.last
@@ -54,10 +58,10 @@ class PacketTest < Minitest::Test
   end
 
   def test_manually_create_the_mnemonica_stack # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    clubs = @full_deck.cards.select { |card| card.suit == "C" }
-    hearts = @full_deck.cards.select { |card| card.suit == "H" }
-    spades = @full_deck.cards.select { |card| card.suit == "S" }
-    diamonds = @full_deck.cards.select { |card| card.suit == "D" }
+    clubs = create_full_deck.cards.select { |card| card.suit == "C" }
+    hearts = create_full_deck.cards.select { |card| card.suit == "H" }
+    spades = create_full_deck.cards.select { |card| card.suit == "S" }
+    diamonds = create_full_deck.cards.select { |card| card.suit == "D" }
 
     # reverse hearts and clubs
     deck = Packet.new(cards: [spades, hearts, diamonds.reverse, clubs.reverse].flatten)
@@ -91,20 +95,20 @@ class PacketTest < Minitest::Test
 
   def test_cutting_a_negative_amout_of_cards_raises_an_error
     assert_raises(ArgumentError) do
-      @full_deck.cut(number: -10)
+      create_full_deck.cut(number: -10)
     end
   end
 
   def test_riffle_shuffle_shuffles_the_deck # rubocop:disable Metrics/AbcSize
-    original_cards = @full_deck.cards.dup
-    original_clubs = @full_deck.cards.select { |card| card.suit == "C" }.dup
+    original_cards = create_full_deck.cards.dup
+    original_clubs = create_full_deck.cards.select { |card| card.suit == "C" }.dup
 
-    left_half = @full_deck.cut(number: 26)
-    @full_deck.riffle_shuffle(other_packet: left_half)
+    left_half = create_full_deck.cut(number: 26)
+    create_full_deck.riffle_shuffle(other_packet: left_half)
 
-    clubs = @full_deck.cards.select { |card| card.suit == "C" }
+    clubs = create_full_deck.cards.select { |card| card.suit == "C" }
 
-    refute_equal original_cards.map(&:to_s), @full_deck.cards.to_s
+    refute_equal original_cards.map(&:to_s), create_full_deck.cards.to_s
     assert_equal original_clubs.map(&:to_s), clubs.map(&:to_s)
   end
 
@@ -134,39 +138,43 @@ class PacketTest < Minitest::Test
   end
 
   def test_deal_deals_the_top_card
-    card = @full_deck.deal
+    deck = create_full_deck
+    card = deck.deal
 
     assert_equal "A of C", card.to_s
-    assert_equal 51, @full_deck.size
+    assert_equal 51, deck.size
   end
 
   def test_bottom_deal_deals_the_bottom_card
-    card = @full_deck.bottom_deal
+    deck = create_full_deck
+    card = deck.bottom_deal
 
     assert_equal "K of D", card.to_s
-    assert_equal 51, @full_deck.size
+    assert_equal 51, deck.size
   end
 
   def test_deal_into_piles_deals_into_x_number_of_piles
-    piles = @full_deck.deal_into_piles(number_of_piles: 4, number_of_cards: 5)
+    deck = create_full_deck
+    piles = deck.deal_into_piles(number_of_piles: 4, number_of_cards: 5)
 
     assert_equal 4, piles.size
     assert(piles.all? { _1.size == 5 })
-    assert_equal 32, @full_deck.size
+    assert_equal 32, deck.size
   end
 
   def test_deal_into_piles_deals_into_x_number_of_piles_raises_on_invalid_numbers
     assert_raises do
-      @full_deck.deal_into_piles(number_of_piles: 4, number_of_cards: -5)
+      create_full_deck.deal_into_piles(number_of_piles: 4, number_of_cards: -5)
     end
 
     assert_raises do
-      @full_deck.deal_into_piles(number_of_piles: -4, number_of_cards: 5)
+      create_full_deck.deal_into_piles(number_of_piles: -4, number_of_cards: 5)
     end
   end
 
   private
 
+  sig { returns(Packet) }
   def create_full_deck
     cards = []
     Card.suits.each do |suit|


### PR DESCRIPTION
# Move set_cards_positions to class method

Refactors the `set_cards_positions` method from an instance method to a class method, improving encapsulation by making it a private class method that's only used during packet creation.

## Refactoring packet tests

- Removes the `@full_deck` instance variable in favor of creating fresh decks in each test
- Adds Sorbet typing to help navigate with LSP
- Improves test clarity with explicit type assertions
- Adds test to verify card positions are properly set when building from a text file