### PR TITLE
Extract Cuts module from Packet class

### DIFF
--- a/lib/deck_of_cards/packet/cuts.rb
+++ b/lib/deck_of_cards/packet/cuts.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# typed: true
+
+# Includes cutting methods, either splits or assembles packets of cards
+module Cuts
+  extend T::Helpers
+  extend T::Sig
+  requires_ancestor { Packet }
+
+  sig { params(number: Integer).returns(Packet) }
+  def cut(number:)
+    raise ArgumentError if invalid_number_to_cut_to?(number)
+
+    cut_cards = cards.slice!(0...number)
+    Packet.new(cards: T.must(cut_cards))
+  end
+
+  sig { params(number: Integer).void }
+  def cut_and_complete(number:)
+    top_half = cut(number:)
+    self.cards = [cards, top_half.cards].flatten
+  end
+
+  private
+
+  sig { params(number: Integer).returns(T::Boolean) }
+  def invalid_number_to_cut_to?(number)
+    return true if number.negative?
+    return true if number.zero?
+    return true if number >= cards.size
+
+    false
+  end
+end

--- a/lib/deck_of_cards/packet/packet.rb
+++ b/lib/deck_of_cards/packet/packet.rb
@@ -6,7 +6,9 @@ class Packet
   extend T::Sig
   require "deck_of_cards/packet/shuffles"
   require "deck_of_cards/packet/deals"
+  require "deck_of_cards/packet/cuts"
   include Deals
+  include Cuts
 
   sig { returns(T::Array[Card]) }
   attr_accessor :cards
@@ -60,27 +62,6 @@ class Packet
     end
   end
 
-  sig { params(number: Integer).returns(Packet) }
-  def cut(number:)
-    raise ArgumentError if invalid_number_to_cut_to?(number)
-    return self if number >= size
-
-    cut_cards = cards.slice!(0...number)
-    Packet.new(cards: T.must(cut_cards))
-  end
-
-  sig { params(number: Integer).void }
-  def cut_and_complete(number:)
-    top_half = cut(number:)
-    self.cards = [cards, top_half.cards].flatten
-  end
-
-  sig { params(number: Integer).returns(Packet) }
-  def cut_and_complete!(number:)
-    cut_and_complete(number:)
-    self
-  end
-
   sig { params(other_packet: Packet).void }
   def faro(other_packet:)
     self.cards = Shuffles.faro_shuffle(top_half: self, bottom_half: other_packet)
@@ -91,31 +72,18 @@ class Packet
     self.cards = Shuffles.riffle_shuffle(left_half: self, right_half: other_packet)
   end
 
-  sig { returns(Packet) }
+  sig { void }
   def shuffle
     self.cards = cards.shuffle
-    self
   end
 
-  sig { returns(Packet) }
+  sig { void }
   def reverse
     self.cards = cards.reverse
-    self
   end
 
   sig { returns(T::Array[String]) }
   def to_s
     cards.map(&:to_s)
-  end
-
-  private
-
-  sig { params(number: Integer).returns(T::Boolean) }
-  def invalid_number_to_cut_to?(number)
-    return true if number.negative?
-    return true if number.zero?
-    return true if number >= cards.size
-
-    false
   end
 end

--- a/test/test_packet.rb
+++ b/test/test_packet.rb
@@ -33,6 +33,13 @@ class PacketTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     assert_equal 26, deck.size
   end
 
+  def test_cut_and_complete_returns_the_cutted_deck
+    deck = mnemonica_deck
+    deck.cut_and_complete(number: 26)
+    new_top_card = T.must(deck.cards.first)
+    assert_equal 27, new_top_card.position
+  end
+
   def test_faro_two_packets_of_cards # rubocop:disable Metrics/AbcSize
     deck = create_full_deck
 
@@ -183,5 +190,11 @@ class PacketTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       end
     end
     Packet.new(cards:)
+  end
+
+  sig { returns(Packet) }
+  def mnemonica_deck
+    file_path = "data/mnemonica.txt"
+    Packet.build_from_text_file(file_path:)
   end
 end


### PR DESCRIPTION
### TL;DR

Refactored card cutting functionality into a dedicated `Cuts` module and improved method return types.

### What changed?

- Created a new `Cuts` module in `lib/deck_of_cards/packet/cuts.rb` to encapsulate card cutting functionality
- Moved `cut`, `cut_and_complete`, and `invalid_number_to_cut_to?` methods from `Packet` class to the new module
- Included the `Cuts` module in the `Packet` class
- Fixed method return types: `shuffle` and `reverse` methods now return `void` instead of `Packet`
- Removed the `cut_and_complete!` method which is no longer needed
- Added a test for `cut_and_complete` to verify it returns the cutted deck
- Added a helper method `mnemonica_deck` in the test file for easier test setup

### How to test?

1. Run the test suite to verify all tests pass
2. Specifically check the new test `test_cut_and_complete_returns_the_cutted_deck`
3. Verify that existing functionality using `cut` and `cut_and_complete` methods still works as expected

### Why make this change?

This change improves code organization by separating concerns into dedicated modules. The `Cuts` module now handles all card cutting operations, making the codebase more maintainable and easier to understand. The method return type corrections also make the API more consistent and predictable.