### PR TITLE
Add cull method to Packet class

### DIFF
--- a/lib/deck_of_cards_handler/packet/packet.rb
+++ b/lib/deck_of_cards_handler/packet/packet.rb
@@ -10,6 +10,7 @@ class Packet
   require "deck_of_cards_handler/packet/cuts"
   include Deals
   include Cuts
+  include Shuffles
 
   sig { returns(T::Array[Card]) }
   attr_accessor :cards

--- a/lib/deck_of_cards_handler/packet/packet.rb
+++ b/lib/deck_of_cards_handler/packet/packet.rb
@@ -93,6 +93,16 @@ class Packet
     self.cards = cards.reverse
   end
 
+  # Moves a card from position A to position B
+  # The first card position IS 1, NOT 0 as in a traditional array
+  sig { params(from: Integer, to: Integer).void }
+  def cull(from:, to:)
+    raise ArgumentError, "`from` must be in range with 1..#{size}" if from <= 0 || from > size
+    raise ArgumentError, "`to` must be in range with 1..#{size}" if to <= 0 || to > size
+
+    cards.insert(to - 1, T.must(cards.delete_at(from - 1)))
+  end
+
   sig { void }
   def set_cards_positions
     cards.each_with_index do |card, index|

--- a/lib/deck_of_cards_handler/packet/shuffles.rb
+++ b/lib/deck_of_cards_handler/packet/shuffles.rb
@@ -2,6 +2,24 @@
 # typed: strict
 
 module Shuffles
+  extend T::Helpers
+  extend T::Sig
+
+  requires_ancestor { Packet }
+
+  sig { void }
+  def overhand_shuffle
+    piles = []
+
+    until size.zero?
+      chunk_size = Kernel.rand(1..8)
+      chunk_size = size if chunk_size > size
+      piles << cut(number: chunk_size)
+    end
+
+    reassemble_right_to_left_on_top(piles)
+  end
+
   class << self
     extend T::Sig
 

--- a/test/test_packet.rb
+++ b/test/test_packet.rb
@@ -257,6 +257,13 @@ class PacketTest < Minitest::Test
     end
   end
 
+  def test_overhand_shuffle
+    deck = mnemonica_deck
+    deck.overhand_shuffle
+
+    refute_equal mnemonica_deck.to_s, deck.to_s
+  end
+
   private
 
   sig { returns(Packet) }

--- a/test/test_packet.rb
+++ b/test/test_packet.rb
@@ -245,6 +245,18 @@ class PacketTest < Minitest::Test
     assert_equal expected_cards, deck.cards.last(5)
   end
 
+  def test_cull
+    deck = mnemonica_deck
+    deck.cull(from: 1, to: 52)
+
+    expected_card = Card.new(suit: "C", value: "4")
+    assert_equal expected_card, deck.cards.last
+
+    assert_raises do
+      deck.cull(from: 53, to: 0)
+    end
+  end
+
   private
 
   sig { returns(Packet) }


### PR DESCRIPTION
# Add cull method to Packet class and overhand shuffle method

- Added `cull` method to move a card from one position to another in the packet
- Implemented `overhand_shuffle` method in the Shuffles module
- Added tests for both new methods

The cull method uses 1-based indexing (first card is position 1, not 0) to match card handling conventions.