### PR TITLE
Version bump to 0.1.92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,8 @@
 ## [0.1.6] - 2025-10-20
 
 - Added poker hand comparison
+
+## [0.1.92] - 2025-10-21
+
+- Added overhand shuffle
+- Added cull method

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deck_of_cards_handler (0.1.91)
+    deck_of_cards_handler (0.1.92)
       sorbet-runtime (>= 0.6)
 
 GEM

--- a/lib/deck_of_cards_handler/version.rb
+++ b/lib/deck_of_cards_handler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeckOfCardsHandler
-  VERSION = "0.1.91"
+  VERSION = "0.1.92"
 end


### PR DESCRIPTION
### TL;DR

Bump version to 0.1.92 and update changelog with new card manipulation features.

### What changed?

- Incremented version from 0.1.91 to 0.1.92 in both `version.rb` and `Gemfile.lock`
- Added new entries to the changelog documenting two new features:
  - Overhand shuffle functionality
  - Cull method for card manipulation

### How to test?

1. Verify the version number is correctly updated to 0.1.92
2. Test the new overhand shuffle functionality with a deck
3. Test the new cull method to ensure it works as expected

### Why make this change?

This version bump adds two important card manipulation techniques that enhance the library's capabilities for card games and magic tricks. The overhand shuffle provides a more realistic shuffling method, while the cull method allows for controlled card manipulation.